### PR TITLE
fix mediaserver custom_button + colores en dialogos

### DIFF
--- a/python/version-mediaserver/platformcode/controllers/html.py
+++ b/python/version-mediaserver/platformcode/controllers/html.py
@@ -283,6 +283,7 @@ class platform(Platformtools):
         text = line1
         if line2: text += "\n" + line2
         if line3: text += "\n" + line3
+        text = self.kodi_labels_to_html(text)
         JsonData = {}
         JsonData["action"]="Alert" 
         JsonData["data"]={}
@@ -300,6 +301,8 @@ class platform(Platformtools):
         text = line1
         if line2: text += "\n" + line2
         if line3: text += "\n" + line3
+        text = self.kodi_labels_to_html(text)
+        heading = self.kodi_labels_to_html(heading)
         JsonData = {}
         JsonData["action"]="AlertYesNo" 
         JsonData["data"]={}
@@ -311,12 +314,13 @@ class platform(Platformtools):
       
     def dialog_select(self, heading, list): 
         JsonData = {}
+        heading = self.kodi_labels_to_html(heading)
         JsonData["action"]="List"
         JsonData["data"]={}
         JsonData["data"]["title"]=heading
         JsonData["data"]["list"]=[]
         for Elemento in list:
-          JsonData["data"]["list"].append(Elemento)
+          JsonData["data"]["list"].append(self.kodi_labels_to_html(Elemento))
         ID = self.send_message(JsonData)
         response = self.get_data(ID)
 
@@ -327,11 +331,11 @@ class platform(Platformtools):
             def __init__(self, heading, line1, line2, line3, platformtools):
                 self.platformtools = platformtools
                 self.closed = False
-                self.heading = heading
+                self.heading  = self.kodi_labels_to_html(heading)
                 text = line1
                 if line2: text += "\n" + line2
                 if line3: text += "\n" + line3
-                
+                text = self.kodi_labels_to_html(text)
                 JsonData = {}
                 JsonData["action"]="Progress" 
                 JsonData["data"]={}
@@ -355,6 +359,7 @@ class platform(Platformtools):
                 text = line1
                 if line2: text += "\n" + line2
                 if line3: text += "\n" + line3
+                text = self.kodi_labels_to_html(text)
                 JsonData = {}
                 JsonData["action"]="ProgressUpdate" 
                 JsonData["data"]={}
@@ -379,7 +384,8 @@ class platform(Platformtools):
             def __init__(self, heading, message, platformtools):
                 self.platformtools = platformtools
                 self.closed = False
-                self.heading = heading
+                self.heading  = self.kodi_labels_to_html(heading)
+                message = self.kodi_labels_to_html(message)
                 JsonData = {}
                 JsonData["action"]="ProgressBG" 
                 JsonData["data"]={}
@@ -396,6 +402,7 @@ class platform(Platformtools):
 
             def update(self, percent=0, heading="", message=""):
                 JsonData = {}
+                message = self.kodi_labels_to_html(message)
                 JsonData["action"]="ProgressBGUpdate" 
                 JsonData["data"]={}
                 JsonData["data"]["title"]=heading
@@ -417,7 +424,7 @@ class platform(Platformtools):
         JsonData = {}
         JsonData["action"]="Keyboard" 
         JsonData["data"]={}
-        JsonData["data"]["title"]=heading
+        JsonData["data"]["title"] = self.kodi_labels_to_html(heading)
         JsonData["data"]["text"]=default
         JsonData["data"]["password"]=hidden
         ID = self.send_message(JsonData)
@@ -637,7 +644,7 @@ class platform(Platformtools):
       JsonData = {}
       JsonData["action"]="OpenConfig"   
       JsonData["data"]={}
-      JsonData["data"]["title"]=caption
+      JsonData["data"]["title"] = self.kodi_labels_to_html(caption)
       JsonData["data"]["custom_button"]=custom_button
       JsonData["data"]["items"]=[]
       
@@ -720,7 +727,7 @@ class platform(Platformtools):
     def kodi_labels_to_html(self, text):
       text = re.sub(r"(?:\[I\])(.*?)(?:\[/I\])", r"<i>\1</i>", text)
       text = re.sub(r"(?:\[B\])(.*?)(?:\[/B\])", r"<b>\1</b>", text)
-      text = re.sub(r"(?:\[COLOR (?:0x)?([0-F]{2})([0-F]{2})([0-F]{2})([0-F]{2})\])(.*?)(?:\[/COLOR\])", lambda m: "<span style='color: rgba(%s,%s,%s,%s)'>%s</span>" %(int(m.group(2),16), int(m.group(3),16), int(m.group(4),16), int(m.group(1),16) / 255.0, m.group(5)), text)
-      text = re.sub(r"(?:\[COLOR (?:0x)?([0-F]{2})([0-F]{2})([0-F]{2})\])(.*?)(?:\[/COLOR\])", r"<span style='color: #\1\2\3'>\4</span>", text)
+      text = re.sub(r"(?:\[COLOR (?:0x)?([0-f]{2})([0-f]{2})([0-f]{2})([0-f]{2})\])(.*?)(?:\[/COLOR\])", lambda m: "<span style='color: rgba(%s,%s,%s,%s)'>%s</span>" %(int(m.group(2),16), int(m.group(3),16), int(m.group(4),16), int(m.group(1),16) / 255.0, m.group(5)), text)
+      text = re.sub(r"(?:\[COLOR (?:0x)?([0-f]{2})([0-f]{2})([0-f]{2})\])(.*?)(?:\[/COLOR\])", r"<span style='color: #\1\2\3'>\4</span>", text)
       text = re.sub(r"(?:\[COLOR (?:0x)?([a-z|A-Z]+)\])(.*?)(?:\[/COLOR\])", r"<span style='color: \1'>\2</span>", text)
       return text

--- a/python/version-mediaserver/platformcode/template/js/dialogs.js
+++ b/python/version-mediaserver/platformcode/template/js/dialogs.js
@@ -189,9 +189,8 @@ dialog.config = function (id, data, Secciones, Lista) {
     el.RequestID = id;
     el.getElementById("controls_container").innerHTML = Lista;
     el.getElementById("window_heading").innerHTML = data.title;
-
-    if (data["custom_button"] != null) {
-		if  (!data["visible"]) {
+    if (data.custom_button != null) {
+		if  (!data.custom_button.visible) {
 			el.getElementById("custom_button").style.display = "none" 
 		}
 		else {

--- a/python/version-mediaserver/platformcode/template/js/dialogs.js
+++ b/python/version-mediaserver/platformcode/template/js/dialogs.js
@@ -194,7 +194,7 @@ dialog.config = function (id, data, Secciones, Lista) {
 			el.getElementById("custom_button").style.display = "none" 
 		}
 		else {
-			el.getElementById("custom_button").style.visibility = "inline";
+			el.getElementById("custom_button").style.display = "inline";
 			el.getElementById("custom_button").innerHTML = data.custom_button.label;
 			el.getElementById("custom_button").onclick = function () {
 				custom_button(data.custom_button);

--- a/python/version-mediaserver/platformcode/template/js/vars.js
+++ b/python/version-mediaserver/platformcode/template/js/vars.js
@@ -62,7 +62,6 @@ var nav_history = {
     "newResponse": function (data, category) {
         if (!this.confirmed) {
 			if (this.states[this.current].focus >= 0) {
-				console.log(this.states[this.current].focus)
                 document.getElementById("itemlist").children[this.states[this.current].focus].children[0].focus();
                 document.getElementById("itemlist").scrollTop = this.states[this.current].scroll;
             }


### PR DESCRIPTION
**Corregido:**

 - Boton custom_button no aparecía en la ventana de configuración
 - Traducir códigos de color en: Titulos de ventanas (configuración, diálogos, etc...) y mensaje de los diálogos (antes salía [color xxxx][/color] en vez de traducirse al formato HTML
 - Corrección del patrón para traducir los colores, ya que los que estaban en formato hexadecimal 0xFFFFFFFF no se traducían correctamente si no estaban escritos en mayúsculas.

Prueba si todo funciona bien, y si tienes algún problema me avisas, en principio el tema de los colores ya tiene que funcionar bien en mediaserver, si quieres en vez de eliminarlos puedes elegir un color que se vea bien en esta plataforma, como tu quieras.